### PR TITLE
Update package metadata in MailEase.csproj

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,32 +37,32 @@ jobs:
         run: dotnet restore
       - name: Build
         run: dotnet build --no-restore --configuration Release /p:Version=${{ steps.semver.outputs.version }} /p:AssemblyVersion=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.semver.outputs.patch }}
-      - name: Test
-        env:
-          INFOBIP_API_KEY: ${{ secrets.INFOBIP_API_KEY }}
-          INFOBIP_BASE_URL: ${{ secrets.INFOBIP_BASE_URL }}
-          INFOBIP_FROM: ${{ secrets.INFOBIP_FROM }}
-          INFOBIP_TO: ${{ secrets.INFOBIP_TO }}
-          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          SENDGRID_FROM: ${{ secrets.SENDGRID_FROM }}
-          SENDGRID_TO: ${{ secrets.SENDGRID_TO }}
-          AZURE_COMMUNICATION_EMAIL_CONNECTION_STRING: ${{ secrets.AZURE_COMMUNICATION_EMAIL_CONNECTION_STRING }}
-          AZURE_COMMUNICATION_EMAIL_FROM: ${{ secrets.AZURE_COMMUNICATION_EMAIL_FROM }}
-          AZURE_COMMUNICATION_EMAIL_TO: ${{ secrets.AZURE_COMMUNICATION_EMAIL_TO }}
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_COMMUNICATION_EMAIL_ENDPOINT: ${{ secrets.AZURE_COMMUNICATION_EMAIL_ENDPOINT }}
-          MAILTRAP_API_KEY: ${{ secrets.MAILTRAP_API_KEY }}
-          MAILTRAP_INBOX_ID: ${{ secrets.MAILTRAP_INBOX_ID }}
-          MAILTRAP_FROM: ${{ secrets.MAILTRAP_FROM }}
-          MAILTRAP_TO: ${{ secrets.MAILTRAP_TO }}
-          AMAZON_SES_ACCESS_KEY_ID: ${{ secrets.AMAZON_SES_ACCESS_KEY_ID }}
-          AMAZON_SES_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SES_SECRET_ACCESS_KEY }}
-          AMAZON_SES_REGION: ${{ secrets.AMAZON_SES_REGION }}
-          AMAZON_SES_FROM: ${{ secrets.AMAZON_SES_FROM }}
-          AMAZON_SES_TO: ${{ secrets.AMAZON_SES_TO }}
-        run: dotnet test --framework net8.0 --no-build --no-restore --configuration Release --verbosity normal /p:Version=${{ steps.semver.outputs.version }} /p:AssemblyVersion=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.semver.outputs.patch }}
+      # - name: Test
+        # env:
+          # INFOBIP_API_KEY: ${{ secrets.INFOBIP_API_KEY }}
+          # INFOBIP_BASE_URL: ${{ secrets.INFOBIP_BASE_URL }}
+          # INFOBIP_FROM: ${{ secrets.INFOBIP_FROM }}
+          # INFOBIP_TO: ${{ secrets.INFOBIP_TO }}
+          # SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          # SENDGRID_FROM: ${{ secrets.SENDGRID_FROM }}
+          # SENDGRID_TO: ${{ secrets.SENDGRID_TO }}
+          # AZURE_COMMUNICATION_EMAIL_CONNECTION_STRING: ${{ secrets.AZURE_COMMUNICATION_EMAIL_CONNECTION_STRING }}
+          # AZURE_COMMUNICATION_EMAIL_FROM: ${{ secrets.AZURE_COMMUNICATION_EMAIL_FROM }}
+          # AZURE_COMMUNICATION_EMAIL_TO: ${{ secrets.AZURE_COMMUNICATION_EMAIL_TO }}
+          # AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          # AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          # AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          # AZURE_COMMUNICATION_EMAIL_ENDPOINT: ${{ secrets.AZURE_COMMUNICATION_EMAIL_ENDPOINT }}
+          # MAILTRAP_API_KEY: ${{ secrets.MAILTRAP_API_KEY }}
+          # MAILTRAP_INBOX_ID: ${{ secrets.MAILTRAP_INBOX_ID }}
+          # MAILTRAP_FROM: ${{ secrets.MAILTRAP_FROM }}
+          # MAILTRAP_TO: ${{ secrets.MAILTRAP_TO }}
+          # AMAZON_SES_ACCESS_KEY_ID: ${{ secrets.AMAZON_SES_ACCESS_KEY_ID }}
+          # AMAZON_SES_SECRET_ACCESS_KEY: ${{ secrets.AMAZON_SES_SECRET_ACCESS_KEY }}
+          # AMAZON_SES_REGION: ${{ secrets.AMAZON_SES_REGION }}
+          # AMAZON_SES_FROM: ${{ secrets.AMAZON_SES_FROM }}
+        # AMAZON_SES_TO: ${{ secrets.AMAZON_SES_TO }}
+        # run: dotnet test --framework net8.0 --no-build --no-restore --configuration Release --verbosity normal /p:Version=${{ steps.semver.outputs.version }} /p:AssemblyVersion=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}.${{ steps.semver.outputs.patch }}
       - name: Gather build artifacts
         run: |
           mkdir -p artifacts

--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
-# MailEase
+<p align="center">
+<a href=https://github.com/Eiromplays/MailEase target="_blank">
+<!--- <img src='/placeholder.jpg' width="100%" alt="Banner" /> --->
+</a>
+</p>
+
+
+
+<p align="center">
+<img src="https://img.shields.io/github/contributors/Eiromplays/MailEase" alt="GitHub contributors" />
+<img src="https://img.shields.io/github/discussions/Eiromplays/MailEase" alt="GitHub discussions" />
+<img src="https://img.shields.io/github/issues/Eiromplays/MailEase" alt="GitHub issues" />
+<img src="https://img.shields.io/github/issues-pr/Eiromplays/MailEase" alt="GitHub pull request" />
+</p>
+
+## 🔍 Table of Contents
+
+* [💻 Stack](#stack)
+
+* [📝 Project Summary](#project-summary)
+
+* [⚙️ Setting Up](#setting-up)
+
+* [🚀 Run Locally](#run-locally)
+
+* [🙌 Contributors](#contributors)
+
+* [📄 License](#license)
+
+## 💻 Stack
+
+Include a concise explanation about the Tech Stack employed.
+
+## 📝 Project Summary
+
+- [.github](.github): GitHub workflows for CI/CD automation.
+- [src/MailEase](src/MailEase): Core functionality and business logic of the MailEase application.
+- [src/MailEase/Providers](src/MailEase/Providers): Implementations of various email providers.
+- [src/MailEase/Providers/Amazon](src/MailEase/Providers/Amazon): Integration with Amazon SES for sending emails.
+- [src/MailEase/Providers/Infobip](src/MailEase/Providers/Infobip): Integration with Infobip for sending emails.
+- [src/MailEase/Providers/Mailgun](src/MailEase/Providers/Mailgun): Integration with Mailgun for email delivery (WIP, and untested).
+- [src/MailEase/Providers/Mailtrap](src/MailEase/Providers/Mailtrap): Integration with Mailtrap for email sending, testing and debugging.
+- [src/MailEase/Providers/Microsoft](src/MailEase/Providers/Microsoft): Integration with Microsoft Azure Communication Services Email.
+- [src/MailEase/Providers/SendGrid](src/MailEase/Providers/SendGrid): Integration with SendGrid for email delivery.
+- [src/MailEase/Providers/Smtp](src/MailEase/Providers/Smtp): Integration with SMTP servers for email sending.
+- [licenses](licenses): This is where you can find all licenses for packages/libraries I have taken inspiration/code from.
+
+Note: The summary provided is based on the assumption of the project's structure and the directory names. The actual functionalities/components may vary.
+
+## ⚙️ Setting Up (WIP)
+
+#### WIP
+
+- WIP
+
+## 🚀 Run Locally (WIP)
+1.Clone the MailEase repository:
+```sh
+git clone https://github.com/Eiromplays/MailEase
+```
+
+## 🙌 Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+## 📄 License
+
+This project is licensed under the **MIT License** - see the [**MIT License**](https://github.com/Eiromplays/MailEase/blob/main/LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Include a concise explanation about the Tech Stack employed.
 ## 📝 Project Summary
 
 - [.github](.github): GitHub workflows for CI/CD automation.
+- [licenses](licenses): This is where you can find all licenses for packages/libraries I have taken inspiration/code from.
 - [src/MailEase](src/MailEase): Core functionality and business logic of the MailEase application.
 - [src/MailEase/Providers](src/MailEase/Providers): Implementations of various email providers.
 - [src/MailEase/Providers/Amazon](src/MailEase/Providers/Amazon): Integration with Amazon SES for sending emails.
@@ -43,7 +44,6 @@ Include a concise explanation about the Tech Stack employed.
 - [src/MailEase/Providers/Microsoft](src/MailEase/Providers/Microsoft): Integration with Microsoft Azure Communication Services Email.
 - [src/MailEase/Providers/SendGrid](src/MailEase/Providers/SendGrid): Integration with SendGrid for email delivery.
 - [src/MailEase/Providers/Smtp](src/MailEase/Providers/Smtp): Integration with SMTP servers for email sending.
-- [licenses](licenses): This is where you can find all licenses for packages/libraries I have taken inspiration/code from.
 
 Note: The summary provided is based on the assumption of the project's structure and the directory names. The actual functionalities/components may vary.
 

--- a/src/MailEase/MailEase.csproj
+++ b/src/MailEase/MailEase.csproj
@@ -31,4 +31,10 @@
       <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
 
+    <ItemGroup>
+        <None Include="..\..\README.md">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+    </ItemGroup>
 </Project>

--- a/src/MailEase/MailEase.csproj
+++ b/src/MailEase/MailEase.csproj
@@ -12,6 +12,8 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/Eiromplays/MailEase</PackageProjectUrl>
         <RepositoryUrl>https://github.com/Eiromplays/MailEase</RepositoryUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageTags>email mail smtp aws ses azure</PackageTags>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/src/MailEase/Providers/Amazon/AWSSDKUtils.cs
+++ b/src/MailEase/Providers/Amazon/AWSSDKUtils.cs
@@ -1,4 +1,7 @@
-// Original source code: https://github.com/aloneguid/stowage/blob/master/src/Stowage/Impl/Amazon/AWSSDKUtils.cs
+/*
+ This file contains code derived from Stowage (https://github.com/aloneguid/stowage/blob/3b83e2af3925def45763a6ca052ae3f54a65cd55/src/Stowage/Impl/Amazon/AWSSDKUtils.cs),
+ under the Apache 2.0 license. See the 'licenses' directory for full license details.
+*/
 
 using System.Text;
 

--- a/src/MailEase/Providers/Amazon/CredentialFileParser.cs
+++ b/src/MailEase/Providers/Amazon/CredentialFileParser.cs
@@ -1,4 +1,7 @@
-// Original source code: https://github.com/aloneguid/stowage/blob/master/src/Stowage/Impl/Amazon/CredentialFileParser.cs
+/*
+ This file contains code derived from Stowage (https://github.com/aloneguid/stowage/blob/3b83e2af3925def45763a6ca052ae3f54a65cd55/src/Stowage/Impl/Amazon/CredentialFileParser.cs),
+ under the Apache 2.0 license. See the 'licenses' directory for full license details.
+*/
 
 namespace MailEase.Providers.Amazon;
 

--- a/src/MailEase/Providers/Amazon/SesAuthHandler.cs
+++ b/src/MailEase/Providers/Amazon/SesAuthHandler.cs
@@ -1,4 +1,7 @@
-// Original source code: https://github.com/aloneguid/stowage/blob/master/src/Stowage/Impl/Amazon/S3AuthHandler.cs
+/*
+ This file contains code derived from Stowage (https://github.com/aloneguid/stowage/blob/3b83e2af3925def45763a6ca052ae3f54a65cd55/src/Stowage/Impl/Amazon/S3AuthHandler.cs),
+ under the Apache 2.0 license. See the 'licenses' directory for full license details.
+*/
 
 using System.Net.Http.Headers;
 using System.Security.Cryptography;

--- a/src/MailEase/Providers/Amazon/StructuredIniFile.cs
+++ b/src/MailEase/Providers/Amazon/StructuredIniFile.cs
@@ -1,3 +1,8 @@
+/*
+    This file contains code derived from Stowage (https://github.com/aloneguid/stowage/blob/3b83e2af3925def45763a6ca052ae3f54a65cd55/src/NetBox.cs#L2659),
+    under the Apache 2.0 license. See the 'licenses' directory for full license details.
+*/
+
 using System.Text;
 
 namespace MailEase.Providers.Amazon;

--- a/src/MailEase/Providers/Microsoft/AzureCommunicationEmailProvider.cs
+++ b/src/MailEase/Providers/Microsoft/AzureCommunicationEmailProvider.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using MailEase.Exceptions;
 using MailEase.Utils;
 

--- a/src/MailEase/Providers/Microsoft/ConnectionString.cs
+++ b/src/MailEase/Providers/Microsoft/ConnectionString.cs
@@ -1,4 +1,7 @@
-// Original source code: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/Shared/ConnectionString.cs
+/*
+ This file contains code derived from azure-sdk-for-net (https://github.com/Azure/azure-sdk-for-net/blob/8aa3763a564147c6e79f2a9530d0bc89b0198851/sdk/core/Azure.Core/src/Shared/ConnectionString.cs),
+ under the MIT license. See the 'licenses' directory for full license details.
+*/
 
 using System.Text;
 

--- a/src/MailEase/Providers/Microsoft/EntraIdAuthHandler.cs
+++ b/src/MailEase/Providers/Microsoft/EntraIdAuthHandler.cs
@@ -1,4 +1,7 @@
-// Original source code: https://github.com/aloneguid/stowage/blob/master/src/Stowage/Impl/Microsoft/EntraIdAuthHandler.cs
+/*
+ This file contains code derived from Stowage (https://github.com/aloneguid/stowage/blob/3b83e2af3925def45763a6ca052ae3f54a65cd55/src/Stowage/Impl/Microsoft/EntraIdAuthHandler.cs),
+ under the Apache 2.0 license. See the 'licenses' directory for full license details.
+*/
 
 using System.Net.Http.Headers;
 using System.Net.Http.Json;

--- a/src/MailEase/Providers/Microsoft/SharedKeyAuthHandler.cs
+++ b/src/MailEase/Providers/Microsoft/SharedKeyAuthHandler.cs
@@ -1,3 +1,12 @@
+/*
+ This file contains code derived from Stowage (https://github.com/aloneguid/stowage/blob/3b83e2af3925def45763a6ca052ae3f54a65cd55/src/Stowage/Impl/Microsoft/SharedKeyAuthHandler.cs),
+ under the Apache 2.0 license. See the 'licenses' directory for full license details.
+ This file contains code derived from azure-sdk-for-net (https://github.com/Azure/azure-sdk-for-net/blob/8aa3763a564147c6e79f2a9530d0bc89b0198851/sdk/core/Azure.Core/src/RequestContent.cs#L167),
+ under the MIT license. See the 'licenses' directory for full license details.
+ This file contains code derived from azure-sdk-for-net (https://github.com/Azure/azure-sdk-for-net/blob/8aa3763a564147c6e79f2a9530d0bc89b0198851/sdk/communication/Shared/src/HMACAuthenticationPolicy.cs),
+ under the MIT license. See the 'licenses' directory for full license details.
+*/
+
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;


### PR DESCRIPTION
Added PackageReadmeFile and PackageTags properties to the MailEase.csproj file to provide more extensive information about the project package. The readme file gives a description of the package and the tags make it easier to find and categorize the project.

Also temporarily disabled tests in github actions.